### PR TITLE
Modified regex to properly handle both release and releaseversion.

### DIFF
--- a/dsdev_utils/helpers.py
+++ b/dsdev_utils/helpers.py
@@ -137,7 +137,7 @@ class Version(object):
 
     v_re = re.compile('(?P<major>\d+)\.(?P<minor>\d+)\.?(?P'
                       '<patch>\d+)?-?(?P<release>[a,b,e,h,l'
-                      ',p,t]+)?(?P<releaseversion>\d+)?')
+                      ',p,t]+)?-?(?P<releaseversion>\d+)?')
 
     v_re_big = re.compile('(?P<major>\d+)\.(?P<minor>\d+)\.'
                           '(?P<patch>\d+)\.(?P<release>\d+)'


### PR DESCRIPTION
It now will properly handle both a release and releaseversion.  Without the change the releaseversion was not being picked up, and in some situations it would report it as an error.  