### PR TITLE
Handle versions like '1.1.3.0.4'

### DIFF
--- a/dsdev_utils/helpers.py
+++ b/dsdev_utils/helpers.py
@@ -170,10 +170,10 @@ class Version(object):
         if release is None:
             self.release = 2
         # Convert to number for easy comparison and sorting
-        elif release == 'b' or release == 'beta':
+        elif release == '1' or release == 'b' or release == 'beta':
             self.release = 1
             self.channel = 'beta'
-        elif release == 'a' or release == 'alpha':
+        elif release == '0' or release == 'a' or release == 'alpha':
             self.release = 0
             self.channel = 'alpha'
         else:


### PR DESCRIPTION
I found that pyupdater converts versions like `1.1.3alpha4`, passed in like `pyupdater build --app-version=1.1.3alpha4 ...`, to `1.1.3.0.4` which was not being handled correctly by `Version._parse_version_str()`, resulting in things like:
```python
v = Version('1.2.3.0.4')
v.channel #stable
v.release #2 
v.version_str #'1.2.3.2.4'
```
These issues caused an endless loop in pyupdater due to there being no stable release to actually download ;) 

This fixes that issue. 